### PR TITLE
prevents snapping back to original size on hover scale change

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -833,6 +833,7 @@
 
 #navbar nav a 
 {
+	display: inline-block; /* prevents snapping back to original size on hover scale change */ 
 	font-size: 1.15em;
 	font-weight: 250;
 	line-height: 1.5em;


### PR DESCRIPTION
Discovered a fix for this issue here: http://stackoverflow.com/questions/24895483/css-transform-transition-on-hover-snaps-back-to-default-size

Seems to have solved it. Although there was no explanation of why this fixes the issue, just that it does...
