### PR TITLE
disable #navbar height to allow mobile navbar room to expand

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -808,7 +808,7 @@
 	width: 100%;
 	z-index: 5;
 	background: white;
-	height: 75px;
+	/*height: 75px; disabled height to all mobile navbar room */
 
 }
 


### PR DESCRIPTION
Had to disable height and #navbar to allow room for stacked mobile nav. Otherwise 75px was to short for it to display all the verticle links on mobile menu.
